### PR TITLE
Add basic input cleansing for coordinates

### DIFF
--- a/src/Players/util.cpp
+++ b/src/Players/util.cpp
@@ -1,6 +1,7 @@
 #include "hex-ai/Players/util.hpp"
 #include <iostream>
 #include <limits>
+#include <ostream>
 
 using Action = GameState::HexState::Action;
 
@@ -17,15 +18,15 @@ void Players::get_action(Action &a) {
 
         if (std::cin.fail()) {
 
-            // `std::cerr` is an unbuffered output stream. `std::endl` flushes the stream and inserts '\n'
-            std::cerr << "Input should be an integer between 0 and 10" >> std::endl; 
+            // notify user
+            std::cout << "Input should be an integer between 0 and 10 \n";
 
             // now remove `failbit` (error flag) to reset stream state
             std::cin.clear(); 
 
             // ignore entered characters (up to first of max len of streamsize || '\n')
             std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); 
-        } else if (t < 0 || t > 10){
+        } else if (t < 0 || t > 10) {
 
             // stream in good state since number provided so no need to reset state or ignore prev input
             std::cout << "Input should be a number between 0 and 10.\n";
@@ -37,12 +38,12 @@ void Players::get_action(Action &a) {
 
         // again for y-coordinate
     for (;;) {
-        std:cout << "Enter y coordinate: ";
+        std::cout << "Enter y coordinate: ";
         std::cin >> t;
         if (std::cin.fail()) {
-            std::cerr << "Input should be an integer between 0 and 10" >> std::endl; 
+            std::cout << "Input should be an integer between 0 and 10\n";
             std::cin.clear();
-            std::cin.ignore(std::numeric_limits<stream_size>::max(), '\n');
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         } else if (t < 0 || t > 10) {
             std::cout << "Input should be a number between 0 and 10.\n";
         } else a.y = t; break;

--- a/src/Players/util.cpp
+++ b/src/Players/util.cpp
@@ -1,7 +1,6 @@
 #include "hex-ai/Players/util.hpp"
 #include <iostream>
 #include <limits>
-#include <ostream>
 
 using Action = GameState::HexState::Action;
 

--- a/src/Players/util.cpp
+++ b/src/Players/util.cpp
@@ -1,15 +1,51 @@
 #include "hex-ai/Players/util.hpp"
 #include <iostream>
+#include <limits>
 
 using Action = GameState::HexState::Action;
 
 void Players::get_action(Action &a) {
     int t;
-    std::cout << "Enter x coordinate: ";
-    std::cin >> t;
-    a.x = t;
-    std::cout << "Enter y coordinate: ";
-    std::cin >> t;
-    a.y = t;
+
+    // every darn time the user enters the wrong number, we correct them
+    for (;;) { 
+
+        std::cout << "Enter x coordinate: ";
+
+        // store user input in temp variable
+        std::cin >> t;
+
+        if (std::cin.fail()) {
+
+            // `std::cerr` is an unbuffered output stream. `std::endl` flushes the stream and inserts '\n'
+            std::cerr << "Input should be an integer between 0 and 10" >> std::endl; 
+
+            // now remove `failbit` (error flag) to reset stream state
+            std::cin.clear(); 
+
+            // ignore entered characters (up to first of max len of streamsize || '\n')
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); 
+        } else if (t < 0 || t > 10){
+
+            // stream in good state since number provided so no need to reset state or ignore prev input
+            std::cout << "Input should be a number between 0 and 10.\n";
+        } else {
+            a.x = t; 
+            break;
+        }
+    }
+
+        // again for y-coordinate
+    for (;;) {
+        std:cout << "Enter y coordinate: ";
+        std::cin >> t;
+        if (std::cin.fail()) {
+            std::cerr << "Input should be an integer between 0 and 10" >> std::endl; 
+            std::cin.clear();
+            std::cin.ignore(std::numeric_limits<stream_size>::max(), '\n');
+        } else if (t < 0 || t > 10) {
+            std::cout << "Input should be a number between 0 and 10.\n";
+        } else a.y = t; break;
+    }
 }
 


### PR DESCRIPTION
Now whenever the user enters a value that results in an input failure, we clear the stream state, ignore their previous input, and prompt them to re-enter a valid value. There is a lot of repeated code here, so it definitely could be made better. Actually, 95% of it is repeated, so a ton of improvements could be made. But it works for now and was a good learning experience ;)

It ran fine on my end and passed all the existing tests. 